### PR TITLE
Make `edges` a full application

### DIFF
--- a/lib/edges.ex
+++ b/lib/edges.ex
@@ -3,16 +3,18 @@ defmodule Edges do
   Documentation for Edges.
   """
 
-  @doc """
-  Hello world.
+  use Application
 
-  ## Examples
+  alias Edges.Repo
 
-      iex> Edges.hello
-      :world
+  def start(_type, _args) do
+    import Supervisor.Spec
 
-  """
-  def hello do
-    :world
+    children = [
+      supervisor(Repo, [])
+    ]
+
+    opts = [strategy: :one_for_one, name: Edges.Supervisor]
+    Supervisor.start_link(children, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule Edges.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {Edges, []},
       extra_applications: [:logger, :ecto]
     ]
   end

--- a/test/edges_test.exs
+++ b/test/edges_test.exs
@@ -1,8 +1,0 @@
-defmodule EdgesTest do
-  use ExUnit.Case
-  doctest Edges
-
-  test "greets the world" do
-    assert Edges.hello() == :world
-  end
-end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start()
 
-Edges.Repo.start_link()
+Edges.start([], [])
 Ecto.Adapters.SQL.Sandbox.mode(Edges.Repo, :manual)


### PR DESCRIPTION
Adds code to fully encapsulate `edges` into it's own Application.

This means that using it in another application no longer requires manually starting the `Edges.Repo`.  Instead you can just add `:edges` to the `applications` section of `mix.exs` like so:

```
  def application do
    [
      mod: {Axiom.Application, []},
      extra_applications: [:logger, :runtime_tools, :edges]
    ]
  end

```

Also starting it no longer requires internal knowledge of the "library", `Edges.start([], [])`